### PR TITLE
feat: derive tokenId from the ens domain

### DIFF
--- a/tokenid.go
+++ b/tokenid.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
-// DeriveTokenIdFromENSDomain derive token_id from the ENS domain
-func DeriveTokenIdFromENSDomain(backend bind.ContractBackend, domain string) (string, error) {
+// DeriveTokenID derive token_id from the ENS domain
+func DeriveTokenID(backend bind.ContractBackend, domain string) (string, error) {
 	if domain == "" {
 		return "", errors.New("empty domain")
 	}

--- a/tokenid.go
+++ b/tokenid.go
@@ -1,0 +1,40 @@
+// Copyright 2019-2021 Weald Technology Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ens
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+// DeriveTokenIdFromENSDomain derive token_id from the ENS domain
+func DeriveTokenIdFromENSDomain(domain string) (string, error) {
+	domain, err := NormaliseDomain(domain)
+	if err != nil {
+		return "", err
+	}
+	domain, err = DomainPart(domain, 1)
+	if err != nil {
+		return "", err
+	}
+	labelHash, err := LabelHash(domain)
+	hash := fmt.Sprintf("0x%x", labelHash)
+	tokenId, ok := math.ParseBig256(hash)
+	if !ok {
+		return "", err
+	}
+	return tokenId.String(), nil
+
+}

--- a/tokenid.go
+++ b/tokenid.go
@@ -21,7 +21,9 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
-// DeriveTokenID derive token_id from the ENS domain
+// DeriveTokenID derive tokenID from the ENS domain.
+//
+// The tokenID of the ENS name is simply the uint256 representation of the tokenID of ERC721
 func DeriveTokenID(backend bind.ContractBackend, domain string) (string, error) {
 	if domain == "" {
 		return "", errors.New("empty domain")

--- a/tokenid_test.go
+++ b/tokenid_test.go
@@ -1,15 +1,47 @@
 package ens
 
 import (
-	"github.com/stretchr/testify/assert"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestDeriveTokenIdFromENSName(t *testing.T) {
-	exepected := "79233663829379634837589865448569342784712482819484549289560981379859480642508"
-	tokenID, err := DeriveTokenIdFromENSDomain("vitalik.eth")
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		expected string
+		input    string
+		err      string
+	}{
+		{
+			name:     "Valid ENS domain",
+			expected: "79233663829379634837589865448569342784712482819484549289560981379859480642508",
+			input:    "vitalik.eth",
+		},
+		{
+			name:     "Invalid ENS domain",
+			expected: "",
+			input:    "foo.bar",
+			err:      "unregistered name",
+		},
+		{
+			name:     "Blank ENS domain",
+			expected: "",
+			input:    "",
+			err:      "empty domain",
+		},
 	}
-	assert.Equal(t, exepected, tokenID)
+	client, err := ethclient.Dial("https://mainnet.infura.io/v3/831a5442dc2e4536a9f8dee4ea1707a6")
+	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := DeriveTokenIdFromENSDomain(client, test.input)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, actual)
+			}
+		})
+	}
 }

--- a/tokenid_test.go
+++ b/tokenid_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDeriveTokenIdFromENSName(t *testing.T) {
+func TestDeriveTokenId(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected string

--- a/tokenid_test.go
+++ b/tokenid_test.go
@@ -35,7 +35,7 @@ func TestDeriveTokenIdFromENSName(t *testing.T) {
 	require.NoError(t, err)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := DeriveTokenIdFromENSDomain(client, test.input)
+			actual, err := DeriveTokenID(client, test.input)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {

--- a/tokenid_test.go
+++ b/tokenid_test.go
@@ -1,0 +1,15 @@
+package ens
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeriveTokenIdFromENSName(t *testing.T) {
+	exepected := "79233663829379634837589865448569342784712482819484549289560981379859480642508"
+	tokenID, err := DeriveTokenIdFromENSDomain("vitalik.eth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, exepected, tokenID)
+}


### PR DESCRIPTION
I see the [documetation](https://docs.ens.domains/dapp-developer-guide/ens-as-nft), the example is written by Javascript. So, I write the example with Go-ens