### PR TITLE
set UseSTD3ASCIIRules = true for normalization

### DIFF
--- a/namehash.go
+++ b/namehash.go
@@ -27,7 +27,7 @@ var pStrict = idna.New(idna.MapForLookup(), idna.StrictDomainName(true), idna.Tr
 
 // Normalize normalizes a name according to the ENS rules
 func Normalize(input string) (output string, err error) {
-	output, err = p.ToUnicode(input)
+	output, err = pStrict.ToUnicode(input)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
make consistent with https://github.com/ensdomains/eth-ens-namehash/blob/f62f351f8c646b337da2e1eb458a9ea091f35ce7/index.js#L26
and docs
https://docs.ens.domains/contract-api-reference/name-processing#normalising-names